### PR TITLE
Fixed Root Deserialize

### DIFF
--- a/src/binary/de/compound.rs
+++ b/src/binary/de/compound.rs
@@ -31,7 +31,7 @@ impl<'de: 'r, 'r, R: Read + ?Sized> de::MapAccess<'de> for MapAccess<'r, R> {
     where
         K: DeserializeSeed<'de>,
     {
-        self.value_tag = Tag::from_u8(self.reader.read_u8()?)?;
+        self.value_tag = Tag::from_u8(self.reader.read_u8().unwrap_or(0))?;
 
         if self.value_tag == Tag::End {
             return Ok(None);

--- a/src/binary/de/payload.rs
+++ b/src/binary/de/payload.rs
@@ -32,7 +32,7 @@ impl<'de: 'w, 'w, R: Read + ?Sized> de::Deserializer<'de> for PayloadDeserialize
         V: Visitor<'de>,
     {
         match self.tag {
-            Tag::End => unreachable!("invalid payload tag"),
+            Tag::End => visitor.visit_map(MapAccess::new(self.reader, &[])),
             Tag::Byte => visitor.visit_i8(self.reader.read_i8()?),
             Tag::Short => visitor.visit_i16(self.reader.read_i16::<BigEndian>()?),
             Tag::Int => visitor.visit_i32(self.reader.read_i32::<BigEndian>()?),

--- a/src/binary/de/root.rs
+++ b/src/binary/de/root.rs
@@ -39,6 +39,10 @@ impl<R: Read> RootDeserializer<R> {
     fn read_name(&mut self) -> Result<Tag, Error> {
         let tag = Tag::from_u8(self.reader.read_u8()?)?;
 
+        if tag == Tag::End {
+            return Ok(tag)
+        }
+
         if tag != Tag::Compound {
             return Err(Error::new_owned(format!(
                 "unexpected tag `{tag}` (root value must be a compound)"


### PR DESCRIPTION
When deserializing and the root tag is `TAG_End` it should be interpreted that there is no NBT data. In this case, it is necessary that `binary::from_reader()` return an empty `Compound` because it is impossible to tell if the root tag is `TAG_End` while preserving the `reader` before passing it to `binary::from_reader()`. There is an example of this in the NBT data for the [Slot Data structure](https://wiki.vg/Slot_Data), where `TAG_End` represents no NBT data.